### PR TITLE
fix: peft flash attention stream sync

### DIFF
--- a/src/ops/inc_multihead_self_attention.cu
+++ b/src/ops/inc_multihead_self_attention.cu
@@ -1222,6 +1222,9 @@ void flash_compute_attention_kernel_peft(IncMultiHeadSelfAttentionMeta *m,
                                    return_softmax,
                                    gen_,
                                    peft_stream);
+  // todo(gabriele): check if this works as stream guard
+  // checkCUDA(cudaStreamSynchronize(peft_stream));
+
   auto out = result[0];
   auto softmax_lse = result[1];
   auto p = result[2];
@@ -2033,6 +2036,9 @@ void flash_peft_bwd_kernel(IncMultiHeadSelfAttentionMeta *m,
                                    gen_,
                                    rng_state,
                                    peft_stream);
+  // todo(gabriele): check if this works as stream guard
+  // checkCUDA(cudaStreamSynchronize(peft_stream));
+
   auto dq = result[0];
   auto dk = result[1];
   auto dv = result[2];

--- a/src/ops/inc_multihead_self_attention.cu
+++ b/src/ops/inc_multihead_self_attention.cu
@@ -1223,7 +1223,7 @@ void flash_compute_attention_kernel_peft(IncMultiHeadSelfAttentionMeta *m,
                                    gen_,
                                    peft_stream);
   // todo(gabriele): check if this works as stream guard
-  // checkCUDA(cudaStreamSynchronize(peft_stream));
+  checkCUDA(cudaStreamSynchronize(peft_stream));
 
   auto out = result[0];
   auto softmax_lse = result[1];
@@ -2037,7 +2037,7 @@ void flash_peft_bwd_kernel(IncMultiHeadSelfAttentionMeta *m,
                                    rng_state,
                                    peft_stream);
   // todo(gabriele): check if this works as stream guard
-  // checkCUDA(cudaStreamSynchronize(peft_stream));
+  checkCUDA(cudaStreamSynchronize(peft_stream));
 
   auto dq = result[0];
   auto dk = result[1];


### PR DESCRIPTION
**Description of changes:**
Bug fix: The flash attention output is synced with peft_stream. 


**Related Issues:**
I don't think we need an explicit sync with peft_stream as this region task is already guarded by peft_stream. But let's place it here for now.

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #

